### PR TITLE
Update lint.yml to include permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint Check
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Noticed that the lint check is happening, but its failing to post the comment. This is because the workflow was created on a forked repo, so its using the access token from the forked repo instead of the main repo.

- Added permissions, so it is able to post the comment to the PR.

<img width="1517" height="195" alt="image" src="https://github.com/user-attachments/assets/9de7b10c-4b39-4829-b7d7-e99267a3ad74" />
